### PR TITLE
feat: bump repository version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepare": "is-ci || husky install"
   },
   "dependencies": {
+    "lodash": "^4.17.21",
     "nx": "18.0.8"
   },
   "devDependencies": {

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,11 +1,12 @@
 import { getSemanticConfig } from "@cmflow/cli";
+import omit from 'lodash/omit'
 
 process.env.PRODUCTION_BRANCH = "main";
 process.env.DEVELOP_BRANCH = "main";
 process.env.DEPLOY_ON_DOCKER = "false";
 
 export default {
-  ...getSemanticConfig(),
+  ...omit(getSemanticConfig(), ['parserOpts' | 'writerOpts']),
   npmPublish: false,
   // eslint-disable-next-line no-template-curly-in-string
   tagFormat: "v${version}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1727,6 +1727,7 @@ __metadata:
     husky: "npm:^8.0.3"
     is-ci: "npm:^3.0.1"
     lint-staged: "npm:^13.2.2"
+    lodash: "npm:^4.17.21"
     nx: "npm:18.0.8"
     prettier: "npm:^3.2.5"
     rimraf: "npm:^5.0.0"


### PR DESCRIPTION
BREAKING CHANGE: new swagger doc is based on Trident UI and vite bundler